### PR TITLE
fix: prevent mass assignment in updateStudent

### DIFF
--- a/server/controllers/student.controller.js
+++ b/server/controllers/student.controller.js
@@ -155,8 +155,11 @@ const getStudentById = asyncHandler(async (req, res) => {
 });
 
 const updateStudent = asyncHandler(async (req, res) => {
-  const { lang = "en", ...updates } = req.body;
+  const { lang = "en" } = req.body;
   const { id } = req.params;
+
+  const allowedFields = ["name", "email", "courses", "universityId"];
+  const updates = Object.fromEntries(Object.entries(req.body).filter(([k]) => allowedFields.includes(k)));
 
   const updatedStudent = await Student.findByIdAndUpdate(
     id,


### PR DESCRIPTION
fixes a mass assignment vulnerability in the updateStudent endpoint by introducing field whitelisting. Only specific, intended fields can now be updated, preventing unauthorized modifications to sensitive or internal fields